### PR TITLE
Parse data-TRANSIENT log entries for HTTP requests

### DIFF
--- a/dumpio2curl.pl
+++ b/dumpio2curl.pl
@@ -59,7 +59,7 @@ sub req_to_curl {
 
 while(<>) {
 	#[Wed Jan 07 10:50:05.743358 2015] [dumpio:trace7] [pid 21414] mod_dumpio.c(103): [client ::1:33975] mod_dumpio:  dumpio_in (data-HEAP): X-Forwarded-Server: localhost:88\r\n
-	my ($timestamp, $pid, $client, $direction, $data) = /^\[([^\]]*)\]\s+\[dumpio:trace7\]\s+\[pid\s+(\d+)\].*\[client\s+([^\]]+)\]\s+mod_dumpio:\s+dumpio_(\w+)\s+\(data-HEAP\):\s+(.*)$/x;
+	my ($timestamp, $pid, $client, $direction, undef, $data) = /^\[([^\]]*)\]\s+\[dumpio:trace7\]\s+\[pid\s+(\d+)\].*\[client\s+([^\]]+)\]\s+mod_dumpio:\s+dumpio_(\w+)\s+\(data-(HEAP|TRANSIENT)\):\s+(.*)$/x;
 
 	next unless defined($timestamp);
 	next if $data =~ /^(\d+)\sbytes$/; # Just length, not content


### PR DESCRIPTION
Thanks for this tool. Using Apache/2.4.10 I had to tweak the regex, since the dumpio module logs incoming requests as data-TRANSIENT, e.g.

```
[Mon Jul 04 12:19:25.853445 2016] [dumpio:trace7] [pid 4287] mod_dumpio.c(103): [client 1.2.3.4:51268] mod_dumpio:  dumpio_in (data-TRANSIENT): Host: some.host\r\n
```

The change allows to read both data-HEAP and data-TRANSIENT log entries.
